### PR TITLE
Feature/remove old datastore implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,20 +3,20 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "the referencable contracts for event aggregator",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
   "contributors": [
+    "Christian Werner <christian.werner@5minds.de>",
     "Sebastian Meier <sebastian.meier@5minds.de>",
     "Patrick Pötschke <patrick.poetschke@quantusflow.com>",
     "Simon Reymann <simon.reymann@quantusflow.com>"
   ],
-  "dependencies": {
-    "@essential-projects/core_contracts": "^2.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
+    "@essential-projects/iam_contracts": "^3.0.0",
     "@essential-projects/tslint-config": "^1.0.0",
     "gulp": "^3.9.1",
     "gulptraum": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "@essential-projects/iam_contracts": "^3.0.0",
     "@essential-projects/tslint-config": "^1.0.0",
     "gulp": "^3.9.1",
     "gulptraum": "^2.2.4",

--- a/src/ientity_event.ts
+++ b/src/ientity_event.ts
@@ -1,6 +1,5 @@
-import {IEntity} from '@essential-projects/core_contracts';
 import {IDataEvent} from './idata_event';
 
 export interface IEntityEvent extends IDataEvent {
-  source: IEntity;
+  source: any;
 }

--- a/src/ievent_aggregator.ts
+++ b/src/ievent_aggregator.ts
@@ -1,4 +1,3 @@
-import {ExecutionContext} from '@essential-projects/iam_contracts';
 import {ISubscription} from './isubscription';
 
 import {IEvent} from './ievent';
@@ -7,7 +6,7 @@ export interface IEventAggregator {
   publish(event: string | any, data?: any): void;
   subscribe(event: string | Function, callback: Function): ISubscription;
   subscribeOnce(event: string | Function, callback: Function): ISubscription;
-  createEntityEvent(data: any, source: any, context: ExecutionContext, metadataOptions?: {
+  createEntityEvent(data: any, source: any, metadataOptions?: {
     [key: string]: any,
   }): IEvent;
 }

--- a/src/ievent_aggregator.ts
+++ b/src/ievent_aggregator.ts
@@ -1,12 +1,13 @@
-import {ExecutionContext, IEntity} from '@essential-projects/core_contracts';
+import {ExecutionContext} from '@essential-projects/iam_contracts';
 import {ISubscription} from './isubscription';
+
 import {IEvent} from './ievent';
 
 export interface IEventAggregator {
   publish(event: string | any, data?: any): void;
   subscribe(event: string | Function, callback: Function): ISubscription;
   subscribeOnce(event: string | Function, callback: Function): ISubscription;
-  createEntityEvent(data: any, source: IEntity, context: ExecutionContext, metadataOptions?: {
+  createEntityEvent(data: any, source: any, context: ExecutionContext, metadataOptions?: {
     [key: string]: any,
   }): IEvent;
 }

--- a/src/ievent_metadata.ts
+++ b/src/ievent_metadata.ts
@@ -1,9 +1,6 @@
-import {ExecutionContext} from '@essential-projects/iam_contracts';
-
 export interface IEventMetadata {
   id: string;
   applicationId?: string;
-  context: ExecutionContext;
   response?: string;
   options?: {[key: string]: any};
 }

--- a/src/ievent_metadata.ts
+++ b/src/ievent_metadata.ts
@@ -1,4 +1,4 @@
-import {ExecutionContext} from '@essential-projects/core_contracts';
+import {ExecutionContext} from '@essential-projects/iam_contracts';
 
 export interface IEventMetadata {
   id: string;


### PR DESCRIPTION
## What did you change?

Removes all references to `core_contracts`, aswell as the need for an execution context, when creating messages.

## How can others test the changes?

Implement the interfaces in an event aggregator.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
